### PR TITLE
feat(events): add item equip/unequip and player preferences events

### DIFF
--- a/src/Enums/EquipmentSlot.php
+++ b/src/Enums/EquipmentSlot.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AqwSocketClient\Enums;
+
+enum EquipmentSlot: string
+{
+    case Cape = 'ba';
+    case Armor = 'ar';
+    case Costume = 'co';
+    case Weapon = 'Weapon';
+    case Helm = 'he';
+    case House = 'ho';
+    case Pet = 'pe';
+}

--- a/src/Enums/EquipmentSlot.php
+++ b/src/Enums/EquipmentSlot.php
@@ -13,4 +13,5 @@ enum EquipmentSlot: string
     case Helm = 'he';
     case House = 'ho';
     case Pet = 'pe';
+    case Accessory = 'am';
 }

--- a/src/Enums/JsonMessageType.php
+++ b/src/Enums/JsonMessageType.php
@@ -16,6 +16,11 @@ enum JsonMessageType: string
     case EquipItem = 'equipItem';
 
     /**
+     * Message related to a player unequipping an item.
+     */
+    case UnequipItem = 'unequipItem';
+
+    /**
      * Message related to a player changing the appearance of a currently equipped item.
      */
     case WearItem = 'wearItem';

--- a/src/Enums/JsonMessageType.php
+++ b/src/Enums/JsonMessageType.php
@@ -39,4 +39,9 @@ enum JsonMessageType: string
      * Message related to quests information
      */
     case QuestsLoaded = 'getQuests';
+
+    /**
+     * Message related to player cosmetic preferences loaded.
+     */
+    case PreferencesLoaded = 'loadPrefs';
 }

--- a/src/Events/ItemEquippedEvent.php
+++ b/src/Events/ItemEquippedEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AqwSocketClient\Events;
+
+use AqwSocketClient\Enums\EquipmentSlot;
+use AqwSocketClient\Enums\JsonMessageType;
+use AqwSocketClient\Interfaces\EventInterface;
+use AqwSocketClient\Interfaces\MessageInterface;
+use AqwSocketClient\Messages\JsonMessage;
+use AqwSocketClient\Objects\GameFileMetadata;
+use AqwSocketClient\Objects\Identifiers\ItemIdentifier;
+use AqwSocketClient\Objects\Identifiers\SocketIdentifier;
+use AqwSocketClient\Objects\Item\EquippedItem;
+use Override;
+
+final class ItemEquippedEvent implements EventInterface
+{
+    public function __construct(
+        public readonly SocketIdentifier $socketId,
+        public readonly EquippedItem $item,
+    ) {}
+
+    /**
+     * @return ?ItemEquippedEvent
+     */
+    #[Override]
+    public static function from(MessageInterface $message): ?EventInterface
+    {
+        if (!($message instanceof JsonMessage && $message->type === JsonMessageType::EquipItem)) {
+            return null;
+        }
+
+        $data = $message->data;
+        $slot = EquipmentSlot::tryFrom((string) $data['strES']);
+
+        if ($slot === null) {
+            return null;
+        }
+
+        $boost = $data['sMeta'] ?? null;
+
+        return new self(
+            new SocketIdentifier((int) $data['uid']),
+            new EquippedItem(
+                new ItemIdentifier((int) $data['ItemID']),
+                $slot,
+                new GameFileMetadata((string) $data['sLink'], (string) $data['sFile']),
+                $boost !== null ? (string) $boost : null,
+            ),
+        );
+    }
+}

--- a/src/Events/ItemUnequippedEvent.php
+++ b/src/Events/ItemUnequippedEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AqwSocketClient\Events;
+
+use AqwSocketClient\Enums\EquipmentSlot;
+use AqwSocketClient\Enums\JsonMessageType;
+use AqwSocketClient\Interfaces\EventInterface;
+use AqwSocketClient\Interfaces\MessageInterface;
+use AqwSocketClient\Messages\JsonMessage;
+use AqwSocketClient\Objects\Identifiers\ItemIdentifier;
+use AqwSocketClient\Objects\Identifiers\SocketIdentifier;
+use Override;
+
+final class ItemUnequippedEvent implements EventInterface
+{
+    public function __construct(
+        public readonly SocketIdentifier $socketId,
+        public readonly ItemIdentifier $itemId,
+        public readonly EquipmentSlot $slot,
+        public readonly bool $unload,
+    ) {}
+
+    /**
+     * @return ?ItemUnequippedEvent
+     */
+    #[Override]
+    public static function from(MessageInterface $message): ?EventInterface
+    {
+        if (!($message instanceof JsonMessage && $message->type === JsonMessageType::UnequipItem)) {
+            return null;
+        }
+
+        $data = $message->data;
+        $slot = EquipmentSlot::tryFrom((string) $data['strES']);
+
+        if ($slot === null) {
+            return null;
+        }
+
+        return new self(
+            new SocketIdentifier((int) $data['uid']),
+            new ItemIdentifier((int) $data['ItemID']),
+            $slot,
+            (bool) ($data['bUnload'] ?? false),
+        );
+    }
+}

--- a/src/Events/PlayerPreferencesLoadedEvent.php
+++ b/src/Events/PlayerPreferencesLoadedEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AqwSocketClient\Events;
+
+use AqwSocketClient\Enums\EquipmentSlot;
+use AqwSocketClient\Enums\JsonMessageType;
+use AqwSocketClient\Interfaces\EventInterface;
+use AqwSocketClient\Interfaces\MessageInterface;
+use AqwSocketClient\Messages\JsonMessage;
+use AqwSocketClient\Objects\Identifiers\ItemIdentifier;
+use Override;
+
+final class PlayerPreferencesLoadedEvent implements EventInterface
+{
+    /**
+     * @param array<string, ItemIdentifier> $costumes Keyed by EquipmentSlot value
+     */
+    public function __construct(
+        public readonly array $costumes,
+    ) {}
+
+    /**
+     * @return ?PlayerPreferencesLoadedEvent
+     * @mago-ignore analyzer:invalid-iterator
+     */
+    #[Override]
+    public static function from(MessageInterface $message): ?EventInterface
+    {
+        if (!($message instanceof JsonMessage && $message->type === JsonMessageType::PreferencesLoaded)) {
+            return null;
+        }
+
+        $raw = $message->data['result']['costumes'] ?? [];
+        $costumes = [];
+
+        foreach ($raw as $slotValue => $itemId) {
+            $slot = EquipmentSlot::tryFrom((string) $slotValue);
+
+            if ($slot === null) {
+                continue;
+            }
+
+            $costumes[$slot->value] = new ItemIdentifier((int) $itemId);
+        }
+
+        return new self($costumes);
+    }
+}

--- a/src/Helpers/MessageGenerator.php
+++ b/src/Helpers/MessageGenerator.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace AqwSocketClient\Helpers;
 
+use AqwSocketClient\Enums\EquipmentSlot;
 use AqwSocketClient\Objects\Identifiers\AreaIdentifier;
+use AqwSocketClient\Objects\Identifiers\ItemIdentifier;
 use AqwSocketClient\Objects\Identifiers\SocketIdentifier;
 use AqwSocketClient\Objects\Names\AreaName;
 use AqwSocketClient\Objects\Names\PlayerName;
@@ -126,5 +128,34 @@ final class MessageGenerator
     public static function questLoadedWithStaffAndGuildTags(): string
     {
         return '{"t":"xt","b":{"r":-1,"o":{"cmd":"getQuests","quests":{"9999":{"QuestID":9999,"sName":"Staff Guild Quest","sDesc":"A staff guild quest.","sEndText":"Done!","iExp":0,"iGold":0,"iRep":0,"FactionID":1,"sFaction":"Good","iLvl":0,"iReqRep":0,"iReqCP":0,"iClass":0,"bOnce":0,"bUpg":0,"bStaff":1,"bGuild":1,"turnin":[],"reward":[],"reqd":[]}}}}}';
+    }
+
+    public static function equipItem(SocketIdentifier $socketId, ItemIdentifier $itemId, EquipmentSlot $slot): string
+    {
+        return (
+            '{"t":"xt","b":{"r":-1,"o":{"cmd":"equipItem","uid":'
+            . (string) $socketId
+            . ',"ItemID":'
+            . (string) $itemId
+            . ',"strES":"'
+            . $slot->value
+            . '","sFile":"items/equip/armor.swf","sLink":"http://game.aq.com/","sMeta":"AutoAdd"}}}'
+        );
+    }
+
+    public static function equipItemWithoutBoost(
+        SocketIdentifier $socketId,
+        ItemIdentifier $itemId,
+        EquipmentSlot $slot,
+    ): string {
+        return (
+            '{"t":"xt","b":{"r":-1,"o":{"cmd":"equipItem","uid":'
+            . (string) $socketId
+            . ',"ItemID":'
+            . (string) $itemId
+            . ',"strES":"'
+            . $slot->value
+            . '","sFile":"items/equip/armor.swf","sLink":"http://game.aq.com/"}}}'
+        );
     }
 }

--- a/src/Helpers/MessageGenerator.php
+++ b/src/Helpers/MessageGenerator.php
@@ -158,4 +158,17 @@ final class MessageGenerator
             . '","sFile":"items/equip/armor.swf","sLink":"http://game.aq.com/"}}}'
         );
     }
+
+    public static function unequipItem(SocketIdentifier $socketId, ItemIdentifier $itemId, EquipmentSlot $slot): string
+    {
+        return (
+            '{"t":"xt","b":{"r":-1,"o":{"cmd":"unequipItem","uid":'
+            . (string) $socketId
+            . ',"ItemID":'
+            . (string) $itemId
+            . ',"strES":"'
+            . $slot->value
+            . '","bUnload":true}}}'
+        );
+    }
 }

--- a/src/Helpers/MessageGenerator.php
+++ b/src/Helpers/MessageGenerator.php
@@ -171,4 +171,9 @@ final class MessageGenerator
             . '","bUnload":true}}}'
         );
     }
+
+    public static function playerPreferencesLoaded(): string
+    {
+        return '{"t":"xt","b":{"r":-1,"o":{"cmd":"loadPrefs","result":{"costumes":{"co":83965,"ba":59470,"Weapon":59471,"he":74726},"loadouts":{},"prefs":{}},"success":true}}}';
+    }
 }

--- a/src/Objects/Item/EquippedItem.php
+++ b/src/Objects/Item/EquippedItem.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AqwSocketClient\Objects\Item;
+
+use AqwSocketClient\Enums\EquipmentSlot;
+use AqwSocketClient\Objects\GameFileMetadata;
+use AqwSocketClient\Objects\Identifiers\ItemIdentifier;
+
+final readonly class EquippedItem
+{
+    public function __construct(
+        public readonly ItemIdentifier $identifier,
+        public readonly EquipmentSlot $slot,
+        public readonly GameFileMetadata $metadata,
+        public readonly ?string $boost,
+    ) {}
+}

--- a/tests/Unit/Events/ItemEquippedEventTest.php
+++ b/tests/Unit/Events/ItemEquippedEventTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AqwSocketClient\Tests\Unit\Events;
+
+use AqwSocketClient\Enums\EquipmentSlot;
+use AqwSocketClient\Events\ItemEquippedEvent;
+use AqwSocketClient\Helpers\MessageGenerator;
+use AqwSocketClient\Messages\JsonMessage;
+use AqwSocketClient\Objects\Identifiers\ItemIdentifier;
+use AqwSocketClient\Objects\Identifiers\SocketIdentifier;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ItemEquippedEventTest extends TestCase
+{
+    #[Test]
+    public function it_creates_event_on_correct_message(): void
+    {
+        $socketId = new SocketIdentifier(42);
+        $itemId = new ItemIdentifier(1001);
+        $message = JsonMessage::from(MessageGenerator::equipItem($socketId, $itemId, EquipmentSlot::Armor));
+
+        /** @var JsonMessage $message */
+        $event = ItemEquippedEvent::from($message);
+
+        $this->assertInstanceOf(ItemEquippedEvent::class, $event);
+        $this->assertSame(42, $event->socketId->value);
+        $this->assertSame(1001, $event->item->identifier->value);
+        $this->assertSame(EquipmentSlot::Armor, $event->item->slot);
+        $this->assertSame('items/equip/armor.swf', $event->item->metadata->file);
+        $this->assertSame('http://game.aq.com/', $event->item->metadata->link);
+        $this->assertSame('AutoAdd', $event->item->boost);
+    }
+
+    #[Test]
+    public function it_handles_nullable_boost(): void
+    {
+        $socketId = new SocketIdentifier(42);
+        $itemId = new ItemIdentifier(1001);
+        $message = JsonMessage::from(MessageGenerator::equipItemWithoutBoost(
+            $socketId,
+            $itemId,
+            EquipmentSlot::Weapon,
+        ));
+
+        /** @var JsonMessage $message */
+        $event = ItemEquippedEvent::from($message);
+
+        $this->assertInstanceOf(ItemEquippedEvent::class, $event);
+        $this->assertNull($event->item->boost);
+    }
+
+    #[Test]
+    public function it_returns_null_on_unknown_slot(): void
+    {
+        $raw = '{"t":"xt","b":{"r":-1,"o":{"cmd":"equipItem","uid":1,"ItemID":1,"strES":"unknown","sFile":"items/test.swf","sLink":"http://game.aq.com/"}}}';
+        $message = JsonMessage::from($raw);
+
+        /** @var JsonMessage $message */
+        $event = ItemEquippedEvent::from($message);
+
+        $this->assertNull($event);
+    }
+
+    #[Test]
+    public function it_returns_null_on_wrong_message_type(): void
+    {
+        $message = JsonMessage::from(MessageGenerator::loadInventory());
+
+        /** @var JsonMessage $message */
+        $event = ItemEquippedEvent::from($message);
+
+        $this->assertNull($event);
+    }
+}

--- a/tests/Unit/Events/ItemUnequippedEventTest.php
+++ b/tests/Unit/Events/ItemUnequippedEventTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AqwSocketClient\Tests\Unit\Events;
+
+use AqwSocketClient\Enums\EquipmentSlot;
+use AqwSocketClient\Events\ItemUnequippedEvent;
+use AqwSocketClient\Helpers\MessageGenerator;
+use AqwSocketClient\Messages\JsonMessage;
+use AqwSocketClient\Objects\Identifiers\ItemIdentifier;
+use AqwSocketClient\Objects\Identifiers\SocketIdentifier;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ItemUnequippedEventTest extends TestCase
+{
+    #[Test]
+    public function it_creates_event_on_correct_message(): void
+    {
+        $socketId = new SocketIdentifier(51_487);
+        $itemId = new ItemIdentifier(80_006);
+        $message = JsonMessage::from(MessageGenerator::unequipItem($socketId, $itemId, EquipmentSlot::Pet));
+
+        /** @var JsonMessage $message */
+        $event = ItemUnequippedEvent::from($message);
+
+        $this->assertInstanceOf(ItemUnequippedEvent::class, $event);
+        $this->assertSame(51_487, $event->socketId->value);
+        $this->assertSame(80_006, $event->itemId->value);
+        $this->assertSame(EquipmentSlot::Pet, $event->slot);
+        $this->assertTrue($event->unload);
+    }
+
+    #[Test]
+    public function it_defaults_unload_to_false_when_absent(): void
+    {
+        $raw = '{"t":"xt","b":{"r":-1,"o":{"cmd":"unequipItem","uid":1,"ItemID":1,"strES":"ar"}}}';
+        $message = JsonMessage::from($raw);
+
+        /** @var JsonMessage $message */
+        $event = ItemUnequippedEvent::from($message);
+
+        $this->assertInstanceOf(ItemUnequippedEvent::class, $event);
+        $this->assertFalse($event->unload);
+    }
+
+    #[Test]
+    public function it_returns_null_on_unknown_slot(): void
+    {
+        $raw = '{"t":"xt","b":{"r":-1,"o":{"cmd":"unequipItem","uid":1,"ItemID":1,"strES":"unknown","bUnload":true}}}';
+        $message = JsonMessage::from($raw);
+
+        /** @var JsonMessage $message */
+        $event = ItemUnequippedEvent::from($message);
+
+        $this->assertNull($event);
+    }
+
+    #[Test]
+    public function it_returns_null_on_wrong_message_type(): void
+    {
+        $message = JsonMessage::from(MessageGenerator::loadInventory());
+
+        /** @var JsonMessage $message */
+        $event = ItemUnequippedEvent::from($message);
+
+        $this->assertNull($event);
+    }
+}

--- a/tests/Unit/Events/PlayerPreferencesLoadedEventTest.php
+++ b/tests/Unit/Events/PlayerPreferencesLoadedEventTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AqwSocketClient\Tests\Unit\Events;
+
+use AqwSocketClient\Enums\EquipmentSlot;
+use AqwSocketClient\Events\PlayerPreferencesLoadedEvent;
+use AqwSocketClient\Helpers\MessageGenerator;
+use AqwSocketClient\Messages\JsonMessage;
+use AqwSocketClient\Objects\Identifiers\ItemIdentifier;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PlayerPreferencesLoadedEventTest extends TestCase
+{
+    #[Test]
+    public function it_creates_event_on_correct_message(): void
+    {
+        $message = JsonMessage::from(MessageGenerator::playerPreferencesLoaded());
+
+        /** @var JsonMessage $message */
+        $event = PlayerPreferencesLoadedEvent::from($message);
+
+        $this->assertInstanceOf(PlayerPreferencesLoadedEvent::class, $event);
+        $this->assertCount(4, $event->costumes);
+        $this->assertArrayHasKey(EquipmentSlot::Costume->value, $event->costumes);
+        $this->assertArrayHasKey(EquipmentSlot::Cape->value, $event->costumes);
+        $this->assertArrayHasKey(EquipmentSlot::Weapon->value, $event->costumes);
+        $this->assertArrayHasKey(EquipmentSlot::Helm->value, $event->costumes);
+    }
+
+    #[Test]
+    public function it_maps_item_identifiers_correctly(): void
+    {
+        $message = JsonMessage::from(MessageGenerator::playerPreferencesLoaded());
+
+        /** @var JsonMessage $message */
+        $event = PlayerPreferencesLoadedEvent::from($message);
+
+        $this->assertInstanceOf(PlayerPreferencesLoadedEvent::class, $event);
+        $this->assertInstanceOf(ItemIdentifier::class, $event->costumes[EquipmentSlot::Costume->value]);
+        $this->assertSame(83_965, $event->costumes[EquipmentSlot::Costume->value]->value);
+        $this->assertSame(59_470, $event->costumes[EquipmentSlot::Cape->value]->value);
+        $this->assertSame(59_471, $event->costumes[EquipmentSlot::Weapon->value]->value);
+        $this->assertSame(74_726, $event->costumes[EquipmentSlot::Helm->value]->value);
+    }
+
+    #[Test]
+    public function it_skips_unknown_slots(): void
+    {
+        $raw = '{"t":"xt","b":{"r":-1,"o":{"cmd":"loadPrefs","result":{"costumes":{"co":1,"unknown":9999},"loadouts":{},"prefs":{}},"success":true}}}';
+        $message = JsonMessage::from($raw);
+
+        /** @var JsonMessage $message */
+        $event = PlayerPreferencesLoadedEvent::from($message);
+
+        $this->assertInstanceOf(PlayerPreferencesLoadedEvent::class, $event);
+        $this->assertCount(1, $event->costumes);
+        $this->assertArrayNotHasKey('unknown', $event->costumes);
+    }
+
+    #[Test]
+    public function it_returns_empty_costumes_when_absent(): void
+    {
+        $raw = '{"t":"xt","b":{"r":-1,"o":{"cmd":"loadPrefs","result":{"loadouts":{},"prefs":{}},"success":true}}}';
+        $message = JsonMessage::from($raw);
+
+        /** @var JsonMessage $message */
+        $event = PlayerPreferencesLoadedEvent::from($message);
+
+        $this->assertInstanceOf(PlayerPreferencesLoadedEvent::class, $event);
+        $this->assertEmpty($event->costumes);
+    }
+
+    #[Test]
+    public function it_returns_null_on_wrong_message_type(): void
+    {
+        $message = JsonMessage::from(MessageGenerator::loadInventory());
+
+        /** @var JsonMessage $message */
+        $event = PlayerPreferencesLoadedEvent::from($message);
+
+        $this->assertNull($event);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ItemEquippedEvent` for `equipItem` cmd — fires whenever any player in the map equips an item; carries socket ID, item ID, equipment slot, game file metadata, and optional boost modifiers
- Add `ItemUnequippedEvent` for `unequipItem` cmd — complement to equip; carries socket ID, item ID, slot, and `bUnload` flag
- Add `PlayerPreferencesLoadedEvent` for `loadPrefs` cmd — maps cosmetic slot → item ID for the logged-in player
- Add `EquipmentSlot` enum and `EquippedItem` value object shared across the equip events

## Test plan

- [x] `composer quality` passes (lint + analyze + fmt + 198 tests)
- [x] `ItemEquippedEvent`: correct message, nullable boost, unknown slot → null, wrong type → null
- [x] `ItemUnequippedEvent`: correct message, absent bUnload defaults to false, unknown slot → null, wrong type → null
- [x] `PlayerPreferencesLoadedEvent`: correct message, correct IDs, unknown slots skipped, absent costumes → empty, wrong type → null

🤖 Generated with [Claude Code](https://claude.com/claude-code)